### PR TITLE
Fix gifted chat dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.73.0",
     "@supabase/supabase-js": "^2.39.3",
     "axios": "^1.6.7",
-    "gifted-chat": "^2.5.0",
+    "react-native-gifted-chat": "^2.5.0",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "openai": "^4.0.0"

--- a/src/screens/Chat.js
+++ b/src/screens/Chat.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { GiftedChat } from 'gifted-chat';
+import { GiftedChat } from 'react-native-gifted-chat';
 
 export default function Chat() {
   const [messages, setMessages] = useState([]);


### PR DESCRIPTION
## Summary
- use `react-native-gifted-chat` package instead of missing `gifted-chat`
- update chat screen import to match package

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-native-gifted-chat)*

------
https://chatgpt.com/codex/tasks/task_e_68a39a839fc08329aaac2211213c5334