### PR TITLE
Add inflammation score calculation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is a cloud-first health optimization platform using React Native (f
 - Meal photo AI analysis
 - Adaptive AI health agent
 - Progress dashboard
+- Inflammation score calculation endpoint
 
 ## Deployment
 - Frontend: Expo/React Native (deployed via Expo Go or App Store/Play Store)
@@ -33,3 +34,7 @@ The application uses the following environment variables:
 - `SUPABASE_SERVICE_ROLE`: Service role key for privileged Supabase access on the server
 - `OPENAI_API_KEY`: API key used to authenticate with OpenAI services
 - `OPENAI_MODEL`: *(Optional)* model name to override the default OpenAI model
+ 
+### API
+
+- `POST /api/calculate-score` – accepts metrics such as HRV, RHR, sleep score, lab values, and nutrition adherence and returns a 0–100 inflammation score with component breakdown.

--- a/api/calculate-score.js
+++ b/api/calculate-score.js
@@ -1,0 +1,16 @@
+import { calculateScore } from '../lib/score.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    const result = calculateScore(req.body || {});
+    res.status(200).json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: 'invalid_input' });
+  }
+}

--- a/lib/score.js
+++ b/lib/score.js
@@ -1,0 +1,79 @@
+export function calculateScore({
+  hrv,
+  rhr,
+  sleepScore,
+  tg,
+  hdl,
+  hsCRP,
+  nutritionAdherence
+}) {
+  const weights = {
+    labs: 0.5,
+    hrv: 0.2,
+    rhr: 0.1,
+    sleep: 0.1,
+    nutrition: 0.1
+  };
+
+  const components = {};
+  let totalWeight = 0;
+  let weightedScore = 0;
+
+  // Labs component (tg/hdl ratio and hsCRP)
+  let labScores = [];
+  if (tg != null && hdl != null && hdl > 0) {
+    const ratio = tg / hdl;
+    // Ratio <=1 is best (~100), >=4 is worst (~0)
+    const ratioScore = Math.max(0, Math.min(1, (4 - ratio) / 3)) * 100;
+    labScores.push(ratioScore);
+  }
+  if (hsCRP != null) {
+    // hsCRP 0-1 good, 3+ poor
+    const crpScore = Math.max(0, Math.min(1, (3 - hsCRP) / 3)) * 100;
+    labScores.push(crpScore);
+  }
+  if (labScores.length) {
+    const labScore = labScores.reduce((a, b) => a + b, 0) / labScores.length;
+    components.labs = Math.round(labScore);
+    weightedScore += labScore * weights.labs;
+    totalWeight += weights.labs;
+  }
+
+  if (hrv != null) {
+    const hrvScore = Math.min(hrv / 70, 1) * 100; // 70ms+ considered good
+    components.hrv = Math.round(hrvScore);
+    weightedScore += hrvScore * weights.hrv;
+    totalWeight += weights.hrv;
+  }
+
+  if (rhr != null) {
+    const rhrScore = Math.max(0, Math.min(1, (80 - rhr) / 30)) * 100; // 50-80 bpm range
+    components.rhr = Math.round(rhrScore);
+    weightedScore += rhrScore * weights.rhr;
+    totalWeight += weights.rhr;
+  }
+
+  if (sleepScore != null) {
+    const sleepComponent = Math.max(0, Math.min(100, sleepScore));
+    components.sleep = Math.round(sleepComponent);
+    weightedScore += sleepComponent * weights.sleep;
+    totalWeight += weights.sleep;
+  }
+
+  if (nutritionAdherence != null) {
+    const nutritionScore = Math.max(0, Math.min(1, nutritionAdherence)) * 100;
+    components.nutrition = Math.round(nutritionScore);
+    weightedScore += nutritionScore * weights.nutrition;
+    totalWeight += weights.nutrition;
+  }
+
+  const finalScore = totalWeight > 0 ? weightedScore / totalWeight : 0;
+  const confidence = totalWeight; // since weights sum to 1
+
+  return {
+    score: Math.round(finalScore),
+    confidence: Number(confidence.toFixed(2)),
+    components
+  };
+}
+export default calculateScore;

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "Elev8",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "engines": {
     "node": "20.x"
   },
   "scripts": {
     "start": "expo start",
-    "build": "expo export --platform web"
+    "build": "expo export --platform web",
+    "test": "node test/score.test.js"
   },
   "dependencies": {
     "expo": "^51.0.0",

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -36,12 +36,23 @@ create table if not exists data_progress(
   updated_at timestamptz default now()
 );
 
+create table if not exists scores(
+  id bigserial primary key,
+  user_id uuid not null,
+  date date not null,
+  score int not null,
+  components jsonb
+);
+create unique index if not exists scores_uid_date on scores(user_id, date);
+
 alter table wearable_daily enable row level security;
 alter table labs enable row level security;
 alter table meals enable row level security;
 alter table data_progress enable row level security;
+alter table scores enable row level security;
 
 create policy "owner_wearable" on wearable_daily for all using (user_id = auth.uid()) with check (user_id = auth.uid());
 create policy "owner_labs" on labs for all using (user_id = auth.uid()) with check (user_id = auth.uid());
 create policy "owner_meals" on meals for all using (user_id = auth.uid()) with check (user_id = auth.uid());
 create policy "owner_prog" on data_progress for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+create policy "owner_scores" on scores for all using (user_id = auth.uid()) with check (user_id = auth.uid());

--- a/test/score.test.js
+++ b/test/score.test.js
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import { calculateScore } from '../lib/score.js';
+
+// Basic sanity check
+const result = calculateScore({
+  hrv: 60,
+  rhr: 55,
+  sleepScore: 85,
+  tg: 100,
+  hdl: 50,
+  hsCRP: 1,
+  nutritionAdherence: 0.8
+});
+
+assert.ok(result.score >= 0 && result.score <= 100, 'score within 0-100');
+assert.ok(result.confidence > 0, 'confidence computed');
+assert.ok(result.components.hrv, 'component hrv present');
+
+console.log('score test passed');


### PR DESCRIPTION
## Summary
- implement heuristic inflammation score algorithm and expose `POST /api/calculate-score` endpoint
- add Supabase `scores` table definition with RLS policy
- document new API and include basic unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3b2e1f060832990e83950fd5ed182