### PR TITLE
Remove unsupported rootDirectory from vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,5 @@
     "api/**/*": {
       "runtime": "nodejs20.x"
     }
-  },
-  "rootDirectory": "backend"
+  }
 }


### PR DESCRIPTION
## Summary
- fix Vercel configuration by dropping deprecated `rootDirectory` property

## Testing
- `npm test` *(fails: SyntaxError Invalid or unexpected token in test/score.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a45dd147c083299d065a465b4266c4