### PR TITLE
Fix Vercel configuration for supported Node runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,7 @@
 {
   "functions": {
     "api/**/*": {
-      "runtime": "nodejs20.x"
+      "runtime": "nodejs18.x"
     }
-  },
-  "rootDirectory": "backend"
+  }
 }


### PR DESCRIPTION
## Summary
- remove unsupported `rootDirectory` field
- set serverless functions to use Vercel-supported `nodejs18.x` runtime

## Testing
- `npm test` *(fails: SyntaxError Invalid or unexpected token in test/score.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a45dd147c083299d065a465b4266c4