### PR TITLE
Target Node 20 runtime for Vercel functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": ">=20"
   },
   "scripts": {
     "start": "expo start",

--- a/test/score.test.js
+++ b/test/score.test.js
@@ -1,12 +1,3 @@
-
----
-
-# tests/score.test.mjs (final)
-
-> This version works even if `score.js` is located in either `backend/lib/` **or** `lib/`.  
-> (Uses dynamic import with fallback; Node 20+ ESM compatible.)
-
-```js
 import assert from 'assert';
 
 let calculateScore;
@@ -34,3 +25,4 @@ assert.ok(result.confidence > 0, 'confidence computed');
 assert.ok(result.components.hrv, 'component hrv present');
 
 console.log('score test passed');
+


### PR DESCRIPTION
## Summary
- fix Vercel configuration by targeting the Node.js 20 runtime
- require Node engine version >=20 to match deployment environment
- clean up score test to allow automated test execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4697dbc1c83298397d3e523e2ffb0