### PR TITLE
Use supported Node 18 runtime for Vercel functions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,9 @@
 {
   "name": "backend",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",
     "openai": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": ">=18"
   },
   "scripts": {
     "start": "expo start",

--- a/test/score.test.js
+++ b/test/score.test.js
@@ -1,12 +1,3 @@
-
----
-
-# tests/score.test.mjs (final)
-
-> This version works even if `score.js` is located in either `backend/lib/` **or** `lib/`.  
-> (Uses dynamic import with fallback; Node 20+ ESM compatible.)
-
-```js
 import assert from 'assert';
 
 let calculateScore;
@@ -34,3 +25,4 @@ assert.ok(result.confidence > 0, 'confidence computed');
 assert.ok(result.components.hrv, 'component hrv present');
 
 console.log('score test passed');
+

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.js": {
-      "runtime": "nodejs20.x"
+      "runtime": "nodejs18.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure Vercel functions use supported Node 18 runtime
- relax Node engine constraints to >=18 across packages
- keep score test runnable via dynamic ESM import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4697dbc1c83298397d3e523e2ffb0