### PR TITLE
feat: add progress endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Set the following environment variables for development and deployment:
 - `POST /api/calculate-score` – accepts metrics such as HRV, RHR, sleep score, lab values, and nutrition adherence and returns a 0–100 inflammation score with component breakdown.
 - `POST /api/healthgpt/chat` – chat endpoint that references the user's latest stored inflammation score.
 - `GET /api/oura-metrics` – returns latest wearable metrics (HRV, resting heart rate, sleep score, steps) used by the dashboard.
+- `POST /api/progress` – computes a "data readiness" score based on connected sources and stores it in `data_progress`.

--- a/api/progress.js
+++ b/api/progress.js
@@ -1,0 +1,66 @@
+import { getSupabaseClient } from '../lib/withAuth.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  const { supabase, user, error } = await getSupabaseClient(req);
+  if (error) {
+    res.status(401).json({ error });
+    return;
+  }
+
+  const breakdown = { oura: false, labs: false, survey: false, supp: false, meals: false };
+
+  const { count: ouraCount } = await supabase
+    .from('wearable_daily')
+    .select('id', { count: 'exact', head: true });
+  breakdown.oura = (ouraCount || 0) > 0;
+
+  const { count: labCount } = await supabase.from('labs').select('id', { count: 'exact', head: true });
+  breakdown.labs = (labCount || 0) > 0;
+
+  try {
+    const { count: surveyCount } = await supabase
+      .from('user_profile')
+      .select('id', { count: 'exact', head: true });
+    breakdown.survey = (surveyCount || 0) > 0;
+  } catch (e) {
+    breakdown.survey = false;
+  }
+
+  try {
+    const { count: suppCount } = await supabase
+      .from('supp_log')
+      .select('id', { count: 'exact', head: true });
+    breakdown.supp = (suppCount || 0) > 0;
+  } catch (e) {
+    breakdown.supp = false;
+  }
+
+  const { count: mealCount } = await supabase
+    .from('meals')
+    .select('id', { count: 'exact', head: true });
+  breakdown.meals = (mealCount || 0) > 0;
+
+  const score = Math.round(
+    (
+      (breakdown.oura ? 0.3 : 0) +
+      (breakdown.labs ? 0.2 : 0) +
+      (breakdown.survey ? 0.1 : 0) +
+      (breakdown.supp ? 0.2 : 0) +
+      (breakdown.meals ? 0.2 : 0)
+    ) * 100
+  );
+
+  await supabase.from('data_progress').upsert({
+    user_id: user.id,
+    score,
+    breakdown,
+    updated_at: new Date().toISOString(),
+  });
+
+  res.status(200).json({ score, breakdown });
+}

--- a/lib/withAuth.js
+++ b/lib/withAuth.js
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js';
+
+export async function getSupabaseClient(req) {
+  const auth = req.headers['authorization'] || '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+  if (!token) {
+    return { error: 'missing_token' };
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_ANON_KEY,
+    {
+      global: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    }
+  );
+
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data?.user) {
+    return { error: 'invalid_token' };
+  }
+  return { supabase, user: data.user };
+}
+export default getSupabaseClient;


### PR DESCRIPTION
## Summary
- add helper to create authed Supabase client
- implement /api/progress endpoint to compute data readiness score
- document progress endpoint in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e14a74908329a2febc9065f1a667