### PR TITLE
feat: display full oura metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ Set the following environment variables for development and deployment:
 
 - `POST /api/calculate-score` – accepts metrics such as HRV, RHR, sleep score, lab values, and nutrition adherence and returns a 0–100 inflammation score with component breakdown.
 - `POST /api/healthgpt/chat` – chat endpoint that references the user's latest stored inflammation score.
-- `GET /api/oura-metrics` – returns latest wearable metrics (HRV, resting heart rate, sleep score, steps) used by the dashboard.
+- `GET /api/oura-metrics` – aggregates Oura activity, readiness, sleep, heart rate, SpO₂, VO₂ max and more for the dashboard.
 - `POST /api/progress` – computes a "data readiness" score based on connected sources and stores it in `data_progress`.

--- a/api/oura-metrics.js
+++ b/api/oura-metrics.js
@@ -1,14 +1,68 @@
+import axios from 'axios';
+
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
     res.status(405).end();
     return;
   }
-  // Placeholder metrics normally fetched from Oura API
-  const metrics = {
-    hrv: 38, // ms
-    rhr: 57, // bpm
-    sleepScore: 82, // 0-100
-    steps: 7500, // steps
+
+  const token = process.env.OURA_API_TOKEN || process.env.OURA_ACCESS_TOKEN;
+  if (!token) {
+    res.status(500).json({ error: 'Missing Oura API token' });
+    return;
+  }
+
+  const now = new Date();
+  const end = (req.query.end_date || now.toISOString().slice(0, 10));
+  const startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const start = (req.query.start_date || startDate.toISOString().slice(0, 10));
+
+  const endpoints = {
+    dailyActivity: { path: '/daily_activity', params: { start_date: start, end_date: end } },
+    dailyCardiovascularAge: { path: '/daily_cardiovascular_age', params: { start_date: start, end_date: end } },
+    dailyReadiness: { path: '/daily_readiness', params: { start_date: start, end_date: end } },
+    dailyResilience: { path: '/daily_resilience', params: { start_date: start, end_date: end } },
+    dailySleep: { path: '/daily_sleep', params: { start_date: start, end_date: end } },
+    dailySpO2: { path: '/daily_spo2', params: { start_date: start, end_date: end } },
+    heartRate: { path: '/heartrate', params: { start_date: start, end_date: end } },
+    personalInfo: { path: '/personal_info' },
+    restModePeriod: { path: '/rest_mode_period', params: { start_date: start, end_date: end } },
+    ringConfiguration: { path: '/ring_configuration' },
+    session: { path: '/session', params: { start_date: start, end_date: end } },
+    sleep: { path: '/sleep', params: { start_date: start, end_date: end } },
+    sleepTime: { path: '/sleep_time', params: { start_date: start, end_date: end } },
+    vo2Max: { path: '/vo2_max', params: { start_date: start, end_date: end } },
+    workout: { path: '/workout', params: { start_date: start, end_date: end } },
   };
-  res.status(200).json(metrics);
+
+  try {
+    const client = axios.create({
+      baseURL: 'https://api.ouraring.com/v2/usercollection',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const results = await Promise.all(
+      Object.entries(endpoints).map(async ([key, { path, params }]) => {
+        try {
+          const response = await client.get(path, { params });
+          return [key, response.data?.data || response.data];
+        } catch (err) {
+          console.error(`Failed to fetch ${key}:`, err.message);
+          return [key, null];
+        }
+      })
+    );
+
+    const metrics = results.reduce((acc, [key, data]) => {
+      acc[key] = data;
+      return acc;
+    }, {});
+
+    res.status(200).json(metrics);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch metrics' });
+  }
 }

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text, Button, StyleSheet, ScrollView } from 'react-native';
 
 function MetricCard({ icon, label, value }) {
   return (
@@ -30,16 +30,40 @@ export default function Dashboard({ navigation }) {
     loadMetrics();
   }, []);
 
+  const metricDefinitions = [
+    { key: 'dailyActivity', icon: '👟', label: 'Steps', getValue: (m) => m?.dailyActivity?.[0]?.steps },
+    { key: 'dailyCardiovascularAge', icon: '🫀', label: 'Cardio Age', getValue: (m) => m?.dailyCardiovascularAge?.[0]?.cardiovascular_age },
+    { key: 'dailyReadiness', icon: '⚡', label: 'Readiness', getValue: (m) => m?.dailyReadiness?.[0]?.score },
+    { key: 'dailyResilience', icon: '🧘', label: 'Resilience', getValue: (m) => m?.dailyResilience?.[0]?.score },
+    { key: 'dailySleep', icon: '😴', label: 'Sleep Score', getValue: (m) => m?.dailySleep?.[0]?.score },
+    { key: 'dailySpO2', icon: '🫁', label: 'Avg SpO₂', getValue: (m) => m?.dailySpO2?.[0]?.avg_saturation },
+    { key: 'heartRate', icon: '❤️', label: 'Rest HR', getValue: (m) => m?.heartRate?.[0]?.bpm },
+    { key: 'personalInfo', icon: '👤', label: 'Age', getValue: (m) => m?.personalInfo?.age },
+    { key: 'restModePeriod', icon: '🛌', label: 'Rest Mode', getValue: (m) => m?.restModePeriod?.[0]?.start_datetime?.slice(0, 10) },
+    { key: 'ringConfiguration', icon: '💍', label: 'Ring HW', getValue: (m) => m?.ringConfiguration?.hardware_version },
+    { key: 'session', icon: '🎧', label: 'Session', getValue: (m) => m?.session?.[0]?.type },
+    { key: 'sleep', icon: '🛏️', label: 'Sleep Duration', getValue: (m) => m?.sleep?.[0]?.total_sleep_duration },
+    { key: 'sleepTime', icon: '⏰', label: 'Bedtime', getValue: (m) => m?.sleepTime?.[0]?.bedtime_start },
+    { key: 'vo2Max', icon: '🏃', label: 'VO₂ Max', getValue: (m) => m?.vo2Max?.[0]?.vo2_max_ml_per_min_per_kg },
+    { key: 'workout', icon: '🏋️', label: 'Workout Cal', getValue: (m) => m?.workout?.[0]?.calories },
+  ];
+
+  const formatValue = (v) => (v !== undefined && v !== null ? String(v) : 'N/A');
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Dashboard</Text>
       {metrics ? (
-        <View style={styles.metricsGrid}>
-          <MetricCard icon="💓" label="HRV" value={`${metrics.hrv} ms`} />
-          <MetricCard icon="❤️" label="RHR" value={`${metrics.rhr} bpm`} />
-          <MetricCard icon="😴" label="Sleep" value={metrics.sleepScore} />
-          <MetricCard icon="👟" label="Steps" value={metrics.steps} />
-        </View>
+        <ScrollView contentContainerStyle={styles.metricsGrid}>
+          {metricDefinitions.map((def) => (
+            <MetricCard
+              key={def.key}
+              icon={def.icon}
+              label={def.label}
+              value={formatValue(def.getValue(metrics))}
+            />
+          ))}
+        </ScrollView>
       ) : (
         <Text style={styles.subtitle}>{error || 'Loading metrics...'}</Text>
       )}


### PR DESCRIPTION
## Summary
- fetch complete set of Oura metrics including activity, readiness, sleep, SpO2, and VO2 max
- render all available metrics in dashboard cards
- document expanded Oura metrics endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e3927f08832988f27b6a35f5bf7d