### PR TITLE
feat: add Oura webhook and polling edge functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Set the following environment variables for development and deployment:
 - `OURA_CLIENT_ID`: Oura OAuth client ID
 - `OURA_CLIENT_SECRET`: Oura OAuth client secret
 - `OURA_REDIRECT_URI`: Redirect URI for the Oura OAuth callback
+- `OURA_API_TOKEN`: Server token used by background jobs to poll the Oura API
+- `OURA_WEBHOOK_SECRET`: HMAC secret to verify Oura webhook signatures
+- `SUPABASE_FUNCTIONS_URL`: Base URL for invoking other Supabase Edge Functions
 - `JWT_SECRET`: Secret used to sign and verify JWT state parameters
 - `CRON_SECRET`: Secret used to authenticate scheduled cron calls
  
@@ -49,3 +52,5 @@ Set the following environment variables for development and deployment:
 - `POST /api/healthgpt/chat` – chat endpoint that references the user's latest stored inflammation score.
 - `GET /api/oura-metrics` – aggregates Oura activity, readiness, sleep, heart rate, SpO₂, VO₂ max and more for the dashboard.
 - `POST /api/progress` – computes a "data readiness" score based on connected sources and stores it in `data_progress`.
+- **Supabase Edge Function `oura-webhook`** – validates Oura webhook calls and schedules data pulls.
+- **Supabase Edge Function `oura-poll`** – polls the Oura API for the specified window and upserts into `wearable_daily`.

--- a/api/oura-metrics.js
+++ b/api/oura-metrics.js
@@ -13,9 +13,10 @@ export default async function handler(req, res) {
   }
 
   const now = new Date();
-  const end = (req.query.end_date || now.toISOString().slice(0, 10));
+  const { end_date, start_date } = req.query || {};
+  const end = end_date || now.toISOString().slice(0, 10);
   const startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-  const start = (req.query.start_date || startDate.toISOString().slice(0, 10));
+  const start = start_date || startDate.toISOString().slice(0, 10);
 
   const endpoints = {
     dailyActivity: { path: '/daily_activity', params: { start_date: start, end_date: end } },

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -18,9 +18,10 @@ export default function Dashboard({ navigation }) {
   useEffect(() => {
     async function loadMetrics() {
       try {
-        const res = await fetch('/api/oura-metrics');
-        if (!res.ok) throw new Error('network');
+        const base = process.env.EXPO_PUBLIC_API_BASE || '';
+        const res = await fetch(`${base}/api/oura-metrics`);
         const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || 'network');
         setMetrics(data);
       } catch (err) {
         console.error(err);

--- a/supabase/functions/oura-poll/index.ts
+++ b/supabase/functions/oura-poll/index.ts
@@ -1,0 +1,54 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const OURA_TOKEN = Deno.env.get("OURA_API_TOKEN") ?? Deno.env.get("OURA_ACCESS_TOKEN");
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE");
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+  throw new Error("Missing Supabase env vars");
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+
+async function fetchDailySleep(start: string, end: string) {
+  if (!OURA_TOKEN) return [];
+  const url = new URL("https://api.ouraring.com/v2/usercollection/daily_sleep");
+  url.searchParams.set("start_date", start);
+  url.searchParams.set("end_date", end);
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${OURA_TOKEN}` }
+  });
+  if (!resp.ok) {
+    console.error("Oura API error", await resp.text());
+    return [];
+  }
+  const json = await resp.json();
+  return json?.data || [];
+}
+
+serve(async (req) => {
+  try {
+    const { user_id, start, end } = await req.json();
+    if (!user_id || !start || !end) {
+      return new Response("Missing parameters", { status: 400 });
+    }
+
+    const sleeps = await fetchDailySleep(start, end);
+    for (const s of sleeps) {
+      await supabase.from("wearable_daily").upsert({
+        user_id,
+        date: s.day,
+        sleep_score: s.score ?? null,
+        payload: s
+      }, { onConflict: "user_id,date" });
+    }
+
+    return new Response(JSON.stringify({ ok: true, count: sleeps.length }), {
+      headers: { "Content-Type": "application/json" }
+    });
+  } catch (err) {
+    console.error(err);
+    return new Response("Server error", { status: 500 });
+  }
+});

--- a/supabase/functions/oura-webhook/index.ts
+++ b/supabase/functions/oura-webhook/index.ts
@@ -1,0 +1,41 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { HmacSha256 } from "https://deno.land/std@0.224.0/hash/sha256.ts";
+
+const SECRET = Deno.env.get("OURA_WEBHOOK_SECRET") || "";
+const FUNCTIONS_URL = Deno.env.get("SUPABASE_FUNCTIONS_URL");
+
+async function queuePoll(user_id: string, start: string, end: string) {
+  if (!FUNCTIONS_URL) return;
+  await fetch(`${FUNCTIONS_URL}/oura-poll`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id, start, end })
+  });
+}
+
+function verifySignature(body: string, signature: string | null): boolean {
+  if (!SECRET || !signature) return false;
+  const hmac = new HmacSha256(SECRET);
+  hmac.update(body);
+  const digest = "sha256=" + hmac.hex();
+  return digest === signature;
+}
+
+serve(async (req) => {
+  const signature = req.headers.get("x-oura-signature");
+  const body = await req.text();
+  if (!verifySignature(body, signature)) {
+    return new Response("Invalid signature", { status: 401 });
+  }
+
+  const event = JSON.parse(body);
+  const userId = event?.user_id;
+  const start = event?.start_datetime || event?.data?.start_date;
+  const end = event?.end_datetime || event?.data?.end_date || start;
+
+  if (userId && start && end) {
+    await queuePoll(userId, start, end);
+  }
+
+  return new Response("ok", { status: 200 });
+});


### PR DESCRIPTION
## Summary
- add `oura-webhook` Supabase Edge Function to verify webhook signatures and enqueue polling
- add `oura-poll` edge function to fetch daily sleep data from the Oura API and upsert into `wearable_daily`
- document new environment variables and functions in README
- handle missing query params in `GET /api/oura-metrics` and fall back to `OURA_ACCESS_TOKEN`
- log non-OK responses from the Oura API when polling
- use `EXPO_PUBLIC_API_BASE` when fetching dashboard metrics to avoid network errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e601d4648329a4350636a28c5a29